### PR TITLE
Add release notes for 0.229

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -6,6 +6,7 @@ Release Notes
     :maxdepth: 1
 
     release/release-0.228
+    release/release-0.229
     release/release-0.227
     release/release-0.226
     release/release-0.225

--- a/presto-docs/src/main/sphinx/release/release-0.229.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.229.rst
@@ -1,0 +1,30 @@
+=============
+Release 0.229
+=============
+
+General Changes
+_______________
+* Add geospatial function line_interpolate_point.
+* Improve hash value computation for structrual types to avoid collision.
+* Add support for ``CREATE FUNCTION``.
+* Added configs to use common HTTPS settings for internal communications.
+* Add configuration property ``experimental.internal-communication.max-task-update-size`` to limit the size of the taskUpdate.
+* Add peak total memory distribution among tasks of each stage.
+* Respect stage.max-tasks-per-stage to limit number of tasks for scan.
+* Move `SetOperationNode` to SPI. Connectors can now alter query plan to have union, intersect, and except.
+* Start forwarding X_Forwarded_For in header from Proxy.
+
+SPI Changes
+___________
+* Added a new Pinot connector.
+* Split `ConnectorPlanOptimizerProvider` to have two phases for connectors to participate query optimization: `LOGICAL` and `PHYSICAL`. The two phases correspond to pre- and post-shuffle optimization respectively.
+
+Hive Changes
+____________
+* Fix parquet predicate pushdown on dictionaries to consider more than just the first predicate column.
+* Improve parquet predicate pushdown on dictionaries to avoid reading additional data after successfully eliminating a block.
+
+Raptor Changes
+______________
+* Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
+* Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.


### PR DESCRIPTION
# Extracted Release Notes
- #13379 (Author: Vic Zhang): Add peak memory distribution among tasks of each stage
  - Add peak total memory distribution among tasks of each stage.
- #13477 (Author: Cem Cayiroglu): Support max_tasks_per_stage for scan
  - Respect stage.max-tasks-per-stage to limit number of tasks for scan.
- #13504 (Author: Devesh Agrawal): Adding presto-pinot with pushdown working
  - Added a new Pinot connector.
  - Split `ConnectorPlanOptimizerProvider` to have two phases for connectors to participate query optimization: `LOGICAL` and `PHYSICAL`. The two phases correspond to pre- and post-shuffle optimization respectively.
- #13527 (Author: Swapnil Tailor): Passing X_Forwarded_For in header from proxy server
  - Start forwarding X_Forwarded_For in header from Proxy.
- #13535 (Author: Jiexi Lin): Support using remote HDFS as storage in Raptor
  - Change `storage.data-directory` from path to URI. For existing deployment on local flash, a scheme header "file://" should be added to the original config value.
  - Change error code name `RAPTOR_LOCAL_FILE_SYSTEM_ERROR` to `RAPTOR_FILE_SYSTEM_ERROR`.
- #13546 (Author: James Sun): Move SetOperationNode to SPI
  - Move `SetOperationNode` to SPI. Connectors can now alter query plan to have union, intersect, and except.
- #13561 (Author: Leiqing Cai): Support CREATE FUNCTION execution
  - Add support for ``CREATE FUNCTION``.
- #13584 (Author: Nikhil Collooru): Fail query with large taskUpdate size
  - Add configuration property ``experimental.internal-communication.max-task-update-size`` to limit the size of the taskUpdate.
- #13592 (Author: Yi He): Add common InternalCommunicationConfig to turn on HTTPS
  - Added configs to use common HTTPS settings for internal communications.
- #13594 (Author: James Petty): Parquet Dictionary Predicate Pushdown Fixes
  - Fix parquet predicate pushdown on dictionaries to consider more than just the first predicate column.
  - Improve parquet predicate pushdown on dictionaries to avoid reading additional data after successfully eliminating a block.
- #13610 (Author: Wenlei Xie): Add non-linear transformation for structural hash
  - Improve hash value computation for structrual types to avoid collision.
- #13612 (Author: James Gill): Add geospatial function line_interpolate_point
  - Add geospatial function line_interpolate_point.


# Missing Release Notes
## Ajay George
- [ ] https://github.com/jzmq/presto/pull/41 [pull] master from prestodb:master
- [ ] https://github.com/jzmq/presto/pull/18 [pull] master from prestodb:master

## James A. Gill
- [ ] c006c8075038aa5ba73f4f7b388fa8b2ab7da245 Fix GeometryToBingTiles for certain geometries

## Ke Wang
- [ ] b4752ccb4ee2a1717df903d1a0fed110a2df6b18 fix organizationDiscoveryIntervalMillis bug

## Leiqing Cai
- [ ] 7e12d427f748776c47a38eec8f406d528e208246 Add JSON annotations to SqlFunctionId

## Rongrong Zhong
- [ ] https://github.com/prestodb/presto/pull/13384 Function implementation (Merged by: Rongrong Zhong)
- [ ] https://github.com/prestodb/presto/pull/13615 Revert HashBuilderOperator changes (Merged by: Rongrong Zhong)

## Saksham Sachdev
- [ ] https://github.com/prestodb/presto/pull/13526 Implement Basic Example For Jdbc Row Expression Translation (Merged by: James Sun)

## Yi He
- [ ] https://github.com/prestodb/presto/pull/13112 Row expression predicate pushdown (Merged by: James Sun)
- [ ] https://github.com/prestodb/presto/pull/13560 Add RowExpressionPredicateExtractor (Merged by: James Sun)

## oerling@fb.com
- [ ] https://github.com/prestodb/presto/pull/13631 Fix position count of prefilled Blocks (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/13630 Fix getBlockView for all-null SliceDictionarySelectiveReader (Merged by: Maria Basmanova)
- [ ] https://github.com/prestodb/presto/pull/13607 Use fast varint read path in LongInputStreamV1 (Merged by: James Sun)
- [ ] https://github.com/prestodb/presto/pull/13505 Intersect pushdown predicates (Merged by: Rebecca Schlussel)
